### PR TITLE
Fix issue with NPM 7 throwing error

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,8 +97,8 @@
     "resize-observer-polyfill": "^1.5.0"
   },
   "peerDependencies": {
-    "react": "^0.14.0 || ^15.0.1 || ^16.0.0",
-    "react-dom": "^0.14.0 || ^15.0.1 || ^16.0.0"
+    "react": ">= 0.14.0",
+    "react-dom": ">= 0.14.0 "
   },
   "jest": {
     "setupFiles": [


### PR DESCRIPTION
NPM 7 automatically installs peer dependencies. Trying to update to React 17 causes error when installing @ant-design/icons
More info here: https://github.blog/2020-10-13-presenting-v7-0-0-of-the-npm-cli/

Based on the advice from Kent C. Dodds and Cory House, I updated peer dependency of React and React DOM to be ">= 0.14.0"
Tweets: https://mobile.twitter.com/kentcdodds/status/1325565636303482880