### PR TITLE
Add react as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,6 +99,9 @@
     "lodash": "^4.17.21",
     "resize-observer-polyfill": "^1.5.0"
   },
+  "peerDependencies": {
+    "react": ">=16.9.0"
+  },
   "jest": {
     "setupFiles": [
       "./test-setup.js"


### PR DESCRIPTION
Yarn 2 requires all dependencies to be explicit defined. This fixes that for react-slick. Here is some context: https://github.com/ant-design/ant-design/issues/27339

Also, https://github.com/ant-design/react-slick/pull/78 already fixes this, but that was closed for unknown reasons. The difference from that is that I'm only defining react as a peer dependency at it seems like react-dom is not used by this lib.