### PR TITLE
fix: remove unused types

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -9,10 +9,6 @@
 
 import * as React from "react";
 
-type ComponentConstructor<TProps> =
-    | React.ComponentClass<TProps>
-    | React.StatelessComponent<TProps>;
-
 export interface CustomArrowProps {
     className?: string;
     style?: React.CSSProperties;


### PR DESCRIPTION
fix: https://github.com/ant-design/ant-design/issues/35375

ComponentConstructor is not exported and not used, so remove it.